### PR TITLE
Replace all occurences of {field} in URL.

### DIFF
--- a/urlFieldControl.js
+++ b/urlFieldControl.js
@@ -11,7 +11,7 @@ function urlFieldUpdate (workItemServices) {
         
         service.getFieldValues([VSS.getConfiguration().witInputs.Field]).then(function (value) {
             var fieldValue = value[fieldName];
-            url = url.replace('{field}', fieldValue);
+            url = url.replaceAll('{field}', fieldValue);
             if (isEmpty(titleUrlText)) {
                 titleUrlText = url;
             }


### PR DESCRIPTION
First of all - thank you for this great extension.

In my organization, I need to replace all occurences of {field} in the URL. Thus I changed the url.replace to url.replaceAll. This does the job.

Thank you.

P.S. It would be great, if you could accept the pull request from MrBabbelFish, which introduces more fields to the URL :-)